### PR TITLE
refactor(core): typed Column<T> storage, drop archetype chunks

### DIFF
--- a/samples/MyBattleground/PerformanceTinyEcsExample.cs
+++ b/samples/MyBattleground/PerformanceTinyEcsExample.cs
@@ -1,10 +1,108 @@
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using TinyEcs;
 using TinyEcs.Bevy;
 
 public static class PerformanceTinyEcsExample
 {
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static void RunQuery(Query<Data<Position, Velocity>> query)
+	{
+		foreach (var (pos, vel) in query)
+		{
+			pos.Ref.X *= vel.Ref.X;
+			pos.Ref.Y *= vel.Ref.Y;
+		}
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static void RunQueryChunked(Query<Data<Position, Velocity>> query)
+	{
+		var iter = query.Inner.Iter();
+		while (iter.Next())
+		{
+			var posIdx = iter.GetColumnIndexOf<Position>();
+			var velIdx = iter.GetColumnIndexOf<Velocity>();
+			var posSpan = iter.Data<Position>(posIdx);
+			var velSpan = iter.Data<Velocity>(velIdx);
+			for (int i = 0; i < posSpan.Length; i++)
+			{
+				posSpan[i].X *= velSpan[i].X;
+				posSpan[i].Y *= velSpan[i].Y;
+			}
+		}
+	}
+
 	public static void Run()
+	{
+		RunBench("chunked Span<T>", RunQueryChunked);
+		RunBench("foreach (per-row)", RunQuery);
+		RunBenchRaw("raw loop (no app.Update)");
+	}
+
+	static void RunBenchRaw(string label)
+	{
+		using var world = new World();
+		var app = new App(world, ThreadingMode.Single);
+
+		app.AddSystem(Stage.Startup, (Commands cmds) =>
+		{
+			const int ENTITIES_COUNT = (524_288 * 2 * 1);
+			for (int i = 0; i < ENTITIES_COUNT; i++)
+			{
+				cmds.Spawn()
+					.Insert(new Position { X = 0, Y = 0 })
+					.Insert(new Velocity { X = 0, Y = 0 });
+			}
+		});
+		app.RunStartup();
+
+		var query = world.QueryBuilder().With<Position>().With<Velocity>().Build();
+
+		const int RUNS = 3;
+		const int FRAMES_PER_RUN = 3600;
+		var samples = new long[RUNS];
+
+		for (int i = 0; i < FRAMES_PER_RUN; ++i)
+			DoChunked(query);
+
+		for (int r = 0; r < RUNS; r++)
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			var sw = Stopwatch.StartNew();
+			for (int i = 0; i < FRAMES_PER_RUN; ++i)
+				DoChunked(query);
+			sw.Stop();
+			samples[r] = sw.ElapsedMilliseconds;
+		}
+
+		Array.Sort(samples);
+		var median = samples[RUNS / 2];
+		Console.WriteLine($"[{label}] runs: [{string.Join(", ", samples)}] ms, median: {median} ms ({(double)median / FRAMES_PER_RUN:F4} ms/frame)");
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	static void DoChunked(TinyEcs.Query query)
+	{
+		var iter = query.Iter();
+		while (iter.Next())
+		{
+			var posIdx = iter.GetColumnIndexOf<Position>();
+			var velIdx = iter.GetColumnIndexOf<Velocity>();
+			var posSpan = iter.Data<Position>(posIdx);
+			var velSpan = iter.Data<Velocity>(velIdx);
+			for (int i = 0; i < posSpan.Length; i++)
+			{
+				posSpan[i].X *= velSpan[i].X;
+				posSpan[i].Y *= velSpan[i].Y;
+			}
+		}
+	}
+
+	static void RunBench(string label, Action<Query<Data<Position, Velocity>>> system)
 	{
 		using var world = new World();
 		var app = new App(world, ThreadingMode.Single);
@@ -21,20 +119,12 @@ public static class PerformanceTinyEcsExample
 						.Insert(new Velocity { X = 0, Y = 0 });
 				}
 			})
-			.AddSystem(Stage.Update, (Query<Data<Position, Velocity>> query) =>
-			{
-				foreach (var (pos, vel) in query)
-				{
-					pos.Ref.X *= vel.Ref.X;
-					pos.Ref.Y *= vel.Ref.Y;
-				}
-			});
+			.AddSystem(Stage.Update, system);
 
 		const int RUNS = 3;
 		const int FRAMES_PER_RUN = 3600;
 		var samples = new long[RUNS];
 
-		// Warmup pass to let JIT tier up + PGO collect data
 		for (int i = 0; i < FRAMES_PER_RUN; ++i)
 			app.Update();
 
@@ -53,8 +143,7 @@ public static class PerformanceTinyEcsExample
 
 		Array.Sort(samples);
 		var median = samples[RUNS / 2];
-		Console.WriteLine($"runs: [{string.Join(", ", samples)}] ms");
-		Console.WriteLine($"median: {median} ms over {FRAMES_PER_RUN} frames ({(double)median / FRAMES_PER_RUN:F4} ms/frame)");
+		Console.WriteLine($"[{label}] runs: [{string.Join(", ", samples)}] ms, median: {median} ms ({(double)median / FRAMES_PER_RUN:F4} ms/frame)");
 	}
 
 	struct Position

--- a/src/TinyEcs.Bevy/BevySystemParams.cs
+++ b/src/TinyEcs.Bevy/BevySystemParams.cs
@@ -1451,8 +1451,6 @@ public ref struct BevyQueryIter<TQueryData, TQueryFilter>
 	where TQueryData : struct, IData<TQueryData>, allows ref struct
 	where TQueryFilter : struct, IFilter<TQueryFilter>, allows ref struct
 {
-	// Heavy iteration state lives here inline. The Data row is small and
-	// updated in-place across chunks so the per-element foreach copy stays tiny.
 	private TinyEcs.QueryIterator _iterator;
 	private TQueryData _row;
 	private TQueryFilter _filterIterator;
@@ -1461,7 +1459,6 @@ public ref struct BevyQueryIter<TQueryData, TQueryFilter>
 	{
 		_iterator = iterator;
 		_row = default;
-		// Prime the row to an exhausted-chunk state so the first MoveNext pulls a chunk.
 		_filterIterator = TQueryFilter.CreateIterator(iterator);
 		_filterIterator.SetTicks(lastTick, currentTick);
 	}

--- a/src/TinyEcs.Bevy/TinyEcs.Bevy.Data.g.cs
+++ b/src/TinyEcs.Bevy/TinyEcs.Bevy.Data.g.cs
@@ -11,11 +11,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0> : IData<Data<T0>>, IQueryComponentAccess
         where T0 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x1u;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 
@@ -27,7 +31,17 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
+            row._current0 = iterator.GetColumn<T0>(0);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -38,7 +52,13 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
             return true;
         }
 
@@ -60,11 +80,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1> : IData<Data<T0, T1>>, IQueryComponentAccess
         where T0 : struct where T1 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x3u;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -78,8 +102,19 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -90,8 +125,15 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
             return true;
         }
 
@@ -115,11 +157,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2> : IData<Data<T0, T1, T2>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x7u;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -135,9 +181,21 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -148,9 +206,17 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
             return true;
         }
 
@@ -176,11 +242,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3> : IData<Data<T0, T1, T2, T3>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0xFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -198,10 +268,23 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -212,10 +295,19 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
             return true;
         }
 
@@ -243,11 +335,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4> : IData<Data<T0, T1, T2, T3, T4>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x1Fu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -267,11 +363,25 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -282,11 +392,21 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
             return true;
         }
 
@@ -316,11 +436,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5> : IData<Data<T0, T1, T2, T3, T4, T5>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x3Fu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -342,12 +466,27 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -358,12 +497,23 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
             return true;
         }
 
@@ -395,11 +545,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6> : IData<Data<T0, T1, T2, T3, T4, T5, T6>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x7Fu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -423,13 +577,29 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -440,13 +610,25 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
             return true;
         }
 
@@ -480,11 +662,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0xFFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -510,14 +696,31 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -528,14 +731,27 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
             return true;
         }
 
@@ -571,11 +787,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7, T8> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7, T8>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct where T8 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x1FFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -603,15 +823,33 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7, T8> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
-			row._current8 = iterator.GetColumn<T8, DataRow<T8>>(8);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+			row._current8 = iterator.GetColumn<T8>(8);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u) |
+					(row._current8.Value.IsValid() ? (1u << 8) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -622,15 +860,29 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
-			row._current8.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+				row._current8.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
+			if ((m & (1u << 8)) != 0) row._current8.Next();
             return true;
         }
 
@@ -668,11 +920,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct where T8 : struct where T9 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x3FFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -702,16 +958,35 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
-			row._current8 = iterator.GetColumn<T8, DataRow<T8>>(8);
-			row._current9 = iterator.GetColumn<T9, DataRow<T9>>(9);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+			row._current8 = iterator.GetColumn<T8>(8);
+			row._current9 = iterator.GetColumn<T9>(9);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u) |
+					(row._current8.Value.IsValid() ? (1u << 8) : 0u) |
+					(row._current9.Value.IsValid() ? (1u << 9) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -722,16 +997,31 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
-			row._current8.Next();
-			row._current9.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+				row._current8.Next();
+				row._current9.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
+			if ((m & (1u << 8)) != 0) row._current8.Next();
+			if ((m & (1u << 9)) != 0) row._current9.Next();
             return true;
         }
 
@@ -771,11 +1061,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct where T8 : struct where T9 : struct where T10 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x7FFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -807,17 +1101,37 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
-			row._current8 = iterator.GetColumn<T8, DataRow<T8>>(8);
-			row._current9 = iterator.GetColumn<T9, DataRow<T9>>(9);
-			row._current10 = iterator.GetColumn<T10, DataRow<T10>>(10);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+			row._current8 = iterator.GetColumn<T8>(8);
+			row._current9 = iterator.GetColumn<T9>(9);
+			row._current10 = iterator.GetColumn<T10>(10);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u) |
+					(row._current8.Value.IsValid() ? (1u << 8) : 0u) |
+					(row._current9.Value.IsValid() ? (1u << 9) : 0u) |
+					(row._current10.Value.IsValid() ? (1u << 10) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -828,17 +1142,33 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
-			row._current8.Next();
-			row._current9.Next();
-			row._current10.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+				row._current8.Next();
+				row._current9.Next();
+				row._current10.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
+			if ((m & (1u << 8)) != 0) row._current8.Next();
+			if ((m & (1u << 9)) != 0) row._current9.Next();
+			if ((m & (1u << 10)) != 0) row._current10.Next();
             return true;
         }
 
@@ -880,11 +1210,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct where T8 : struct where T9 : struct where T10 : struct where T11 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0xFFFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -918,18 +1252,39 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
-			row._current8 = iterator.GetColumn<T8, DataRow<T8>>(8);
-			row._current9 = iterator.GetColumn<T9, DataRow<T9>>(9);
-			row._current10 = iterator.GetColumn<T10, DataRow<T10>>(10);
-			row._current11 = iterator.GetColumn<T11, DataRow<T11>>(11);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+			row._current8 = iterator.GetColumn<T8>(8);
+			row._current9 = iterator.GetColumn<T9>(9);
+			row._current10 = iterator.GetColumn<T10>(10);
+			row._current11 = iterator.GetColumn<T11>(11);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u) |
+					(row._current8.Value.IsValid() ? (1u << 8) : 0u) |
+					(row._current9.Value.IsValid() ? (1u << 9) : 0u) |
+					(row._current10.Value.IsValid() ? (1u << 10) : 0u) |
+					(row._current11.Value.IsValid() ? (1u << 11) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -940,18 +1295,35 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
-			row._current8.Next();
-			row._current9.Next();
-			row._current10.Next();
-			row._current11.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+				row._current8.Next();
+				row._current9.Next();
+				row._current10.Next();
+				row._current11.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
+			if ((m & (1u << 8)) != 0) row._current8.Next();
+			if ((m & (1u << 9)) != 0) row._current9.Next();
+			if ((m & (1u << 10)) != 0) row._current10.Next();
+			if ((m & (1u << 11)) != 0) row._current11.Next();
             return true;
         }
 
@@ -995,11 +1367,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct where T8 : struct where T9 : struct where T10 : struct where T11 : struct where T12 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x1FFFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -1035,19 +1411,41 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
-			row._current8 = iterator.GetColumn<T8, DataRow<T8>>(8);
-			row._current9 = iterator.GetColumn<T9, DataRow<T9>>(9);
-			row._current10 = iterator.GetColumn<T10, DataRow<T10>>(10);
-			row._current11 = iterator.GetColumn<T11, DataRow<T11>>(11);
-			row._current12 = iterator.GetColumn<T12, DataRow<T12>>(12);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+			row._current8 = iterator.GetColumn<T8>(8);
+			row._current9 = iterator.GetColumn<T9>(9);
+			row._current10 = iterator.GetColumn<T10>(10);
+			row._current11 = iterator.GetColumn<T11>(11);
+			row._current12 = iterator.GetColumn<T12>(12);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u) |
+					(row._current8.Value.IsValid() ? (1u << 8) : 0u) |
+					(row._current9.Value.IsValid() ? (1u << 9) : 0u) |
+					(row._current10.Value.IsValid() ? (1u << 10) : 0u) |
+					(row._current11.Value.IsValid() ? (1u << 11) : 0u) |
+					(row._current12.Value.IsValid() ? (1u << 12) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -1058,19 +1456,37 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
-			row._current8.Next();
-			row._current9.Next();
-			row._current10.Next();
-			row._current11.Next();
-			row._current12.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+				row._current8.Next();
+				row._current9.Next();
+				row._current10.Next();
+				row._current11.Next();
+				row._current12.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
+			if ((m & (1u << 8)) != 0) row._current8.Next();
+			if ((m & (1u << 9)) != 0) row._current9.Next();
+			if ((m & (1u << 10)) != 0) row._current10.Next();
+			if ((m & (1u << 11)) != 0) row._current11.Next();
+			if ((m & (1u << 12)) != 0) row._current12.Next();
             return true;
         }
 
@@ -1116,11 +1532,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct where T8 : struct where T9 : struct where T10 : struct where T11 : struct where T12 : struct where T13 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x3FFFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -1158,20 +1578,43 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
-			row._current8 = iterator.GetColumn<T8, DataRow<T8>>(8);
-			row._current9 = iterator.GetColumn<T9, DataRow<T9>>(9);
-			row._current10 = iterator.GetColumn<T10, DataRow<T10>>(10);
-			row._current11 = iterator.GetColumn<T11, DataRow<T11>>(11);
-			row._current12 = iterator.GetColumn<T12, DataRow<T12>>(12);
-			row._current13 = iterator.GetColumn<T13, DataRow<T13>>(13);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+			row._current8 = iterator.GetColumn<T8>(8);
+			row._current9 = iterator.GetColumn<T9>(9);
+			row._current10 = iterator.GetColumn<T10>(10);
+			row._current11 = iterator.GetColumn<T11>(11);
+			row._current12 = iterator.GetColumn<T12>(12);
+			row._current13 = iterator.GetColumn<T13>(13);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u) |
+					(row._current8.Value.IsValid() ? (1u << 8) : 0u) |
+					(row._current9.Value.IsValid() ? (1u << 9) : 0u) |
+					(row._current10.Value.IsValid() ? (1u << 10) : 0u) |
+					(row._current11.Value.IsValid() ? (1u << 11) : 0u) |
+					(row._current12.Value.IsValid() ? (1u << 12) : 0u) |
+					(row._current13.Value.IsValid() ? (1u << 13) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -1182,20 +1625,39 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
-			row._current8.Next();
-			row._current9.Next();
-			row._current10.Next();
-			row._current11.Next();
-			row._current12.Next();
-			row._current13.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+				row._current8.Next();
+				row._current9.Next();
+				row._current10.Next();
+				row._current11.Next();
+				row._current12.Next();
+				row._current13.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
+			if ((m & (1u << 8)) != 0) row._current8.Next();
+			if ((m & (1u << 9)) != 0) row._current9.Next();
+			if ((m & (1u << 10)) != 0) row._current10.Next();
+			if ((m & (1u << 11)) != 0) row._current11.Next();
+			if ((m & (1u << 12)) != 0) row._current12.Next();
+			if ((m & (1u << 13)) != 0) row._current13.Next();
             return true;
         }
 
@@ -1243,11 +1705,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct where T8 : struct where T9 : struct where T10 : struct where T11 : struct where T12 : struct where T13 : struct where T14 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0x7FFFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -1287,21 +1753,45 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
-			row._current8 = iterator.GetColumn<T8, DataRow<T8>>(8);
-			row._current9 = iterator.GetColumn<T9, DataRow<T9>>(9);
-			row._current10 = iterator.GetColumn<T10, DataRow<T10>>(10);
-			row._current11 = iterator.GetColumn<T11, DataRow<T11>>(11);
-			row._current12 = iterator.GetColumn<T12, DataRow<T12>>(12);
-			row._current13 = iterator.GetColumn<T13, DataRow<T13>>(13);
-			row._current14 = iterator.GetColumn<T14, DataRow<T14>>(14);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+			row._current8 = iterator.GetColumn<T8>(8);
+			row._current9 = iterator.GetColumn<T9>(9);
+			row._current10 = iterator.GetColumn<T10>(10);
+			row._current11 = iterator.GetColumn<T11>(11);
+			row._current12 = iterator.GetColumn<T12>(12);
+			row._current13 = iterator.GetColumn<T13>(13);
+			row._current14 = iterator.GetColumn<T14>(14);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u) |
+					(row._current8.Value.IsValid() ? (1u << 8) : 0u) |
+					(row._current9.Value.IsValid() ? (1u << 9) : 0u) |
+					(row._current10.Value.IsValid() ? (1u << 10) : 0u) |
+					(row._current11.Value.IsValid() ? (1u << 11) : 0u) |
+					(row._current12.Value.IsValid() ? (1u << 12) : 0u) |
+					(row._current13.Value.IsValid() ? (1u << 13) : 0u) |
+					(row._current14.Value.IsValid() ? (1u << 14) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -1312,21 +1802,41 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
-			row._current8.Next();
-			row._current9.Next();
-			row._current10.Next();
-			row._current11.Next();
-			row._current12.Next();
-			row._current13.Next();
-			row._current14.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+				row._current8.Next();
+				row._current9.Next();
+				row._current10.Next();
+				row._current11.Next();
+				row._current12.Next();
+				row._current13.Next();
+				row._current14.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
+			if ((m & (1u << 8)) != 0) row._current8.Next();
+			if ((m & (1u << 9)) != 0) row._current9.Next();
+			if ((m & (1u << 10)) != 0) row._current10.Next();
+			if ((m & (1u << 11)) != 0) row._current11.Next();
+			if ((m & (1u << 12)) != 0) row._current12.Next();
+			if ((m & (1u << 13)) != 0) row._current13.Next();
+			if ((m & (1u << 14)) != 0) row._current14.Next();
             return true;
         }
 
@@ -1376,11 +1886,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> : IData<Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15>>, IQueryComponentAccess
         where T0 : struct where T1 : struct where T2 : struct where T3 : struct where T4 : struct where T5 : struct where T6 : struct where T7 : struct where T8 : struct where T9 : struct where T10 : struct where T11 : struct where T12 : struct where T13 : struct where T14 : struct where T15 : struct
     {
+        private const uint ALL_PRESENT_MASK = 0xFFFFu;
+
 		private static readonly System.Type[] s_componentTypes = new[] { typeof(T0), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8), typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15) };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         internal DataRow<T0> _current0;
 		internal DataRow<T1> _current1;
@@ -1422,22 +1936,47 @@ namespace TinyEcs.Bevy
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void LoadChunk(ref Data<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15> row, QueryIterator iterator)
         {
-            row._current0 = iterator.GetColumn<T0, DataRow<T0>>(0);
-			row._current1 = iterator.GetColumn<T1, DataRow<T1>>(1);
-			row._current2 = iterator.GetColumn<T2, DataRow<T2>>(2);
-			row._current3 = iterator.GetColumn<T3, DataRow<T3>>(3);
-			row._current4 = iterator.GetColumn<T4, DataRow<T4>>(4);
-			row._current5 = iterator.GetColumn<T5, DataRow<T5>>(5);
-			row._current6 = iterator.GetColumn<T6, DataRow<T6>>(6);
-			row._current7 = iterator.GetColumn<T7, DataRow<T7>>(7);
-			row._current8 = iterator.GetColumn<T8, DataRow<T8>>(8);
-			row._current9 = iterator.GetColumn<T9, DataRow<T9>>(9);
-			row._current10 = iterator.GetColumn<T10, DataRow<T10>>(10);
-			row._current11 = iterator.GetColumn<T11, DataRow<T11>>(11);
-			row._current12 = iterator.GetColumn<T12, DataRow<T12>>(12);
-			row._current13 = iterator.GetColumn<T13, DataRow<T13>>(13);
-			row._current14 = iterator.GetColumn<T14, DataRow<T14>>(14);
-			row._current15 = iterator.GetColumn<T15, DataRow<T15>>(15);
+            row._current0 = iterator.GetColumn<T0>(0);
+			row._current1 = iterator.GetColumn<T1>(1);
+			row._current2 = iterator.GetColumn<T2>(2);
+			row._current3 = iterator.GetColumn<T3>(3);
+			row._current4 = iterator.GetColumn<T4>(4);
+			row._current5 = iterator.GetColumn<T5>(5);
+			row._current6 = iterator.GetColumn<T6>(6);
+			row._current7 = iterator.GetColumn<T7>(7);
+			row._current8 = iterator.GetColumn<T8>(8);
+			row._current9 = iterator.GetColumn<T9>(9);
+			row._current10 = iterator.GetColumn<T10>(10);
+			row._current11 = iterator.GetColumn<T11>(11);
+			row._current12 = iterator.GetColumn<T12>(12);
+			row._current13 = iterator.GetColumn<T13>(13);
+			row._current14 = iterator.GetColumn<T14>(14);
+			row._current15 = iterator.GetColumn<T15>(15);
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    (row._current0.Value.IsValid() ? (1u << 0) : 0u) |
+					(row._current1.Value.IsValid() ? (1u << 1) : 0u) |
+					(row._current2.Value.IsValid() ? (1u << 2) : 0u) |
+					(row._current3.Value.IsValid() ? (1u << 3) : 0u) |
+					(row._current4.Value.IsValid() ? (1u << 4) : 0u) |
+					(row._current5.Value.IsValid() ? (1u << 5) : 0u) |
+					(row._current6.Value.IsValid() ? (1u << 6) : 0u) |
+					(row._current7.Value.IsValid() ? (1u << 7) : 0u) |
+					(row._current8.Value.IsValid() ? (1u << 8) : 0u) |
+					(row._current9.Value.IsValid() ? (1u << 9) : 0u) |
+					(row._current10.Value.IsValid() ? (1u << 10) : 0u) |
+					(row._current11.Value.IsValid() ? (1u << 11) : 0u) |
+					(row._current12.Value.IsValid() ? (1u << 12) : 0u) |
+					(row._current13.Value.IsValid() ? (1u << 13) : 0u) |
+					(row._current14.Value.IsValid() ? (1u << 14) : 0u) |
+					(row._current15.Value.IsValid() ? (1u << 15) : 0u);
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -1448,22 +1987,43 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            row._current0.Next();
-			row._current1.Next();
-			row._current2.Next();
-			row._current3.Next();
-			row._current4.Next();
-			row._current5.Next();
-			row._current6.Next();
-			row._current7.Next();
-			row._current8.Next();
-			row._current9.Next();
-			row._current10.Next();
-			row._current11.Next();
-			row._current12.Next();
-			row._current13.Next();
-			row._current14.Next();
-			row._current15.Next();
+            if (!row._anyAbsent)
+            {
+                row._current0.Next();
+				row._current1.Next();
+				row._current2.Next();
+				row._current3.Next();
+				row._current4.Next();
+				row._current5.Next();
+				row._current6.Next();
+				row._current7.Next();
+				row._current8.Next();
+				row._current9.Next();
+				row._current10.Next();
+				row._current11.Next();
+				row._current12.Next();
+				row._current13.Next();
+				row._current14.Next();
+				row._current15.Next();
+                return true;
+            }
+            var m = row._presentMask;
+            if ((m & (1u << 0)) != 0) row._current0.Next();
+			if ((m & (1u << 1)) != 0) row._current1.Next();
+			if ((m & (1u << 2)) != 0) row._current2.Next();
+			if ((m & (1u << 3)) != 0) row._current3.Next();
+			if ((m & (1u << 4)) != 0) row._current4.Next();
+			if ((m & (1u << 5)) != 0) row._current5.Next();
+			if ((m & (1u << 6)) != 0) row._current6.Next();
+			if ((m & (1u << 7)) != 0) row._current7.Next();
+			if ((m & (1u << 8)) != 0) row._current8.Next();
+			if ((m & (1u << 9)) != 0) row._current9.Next();
+			if ((m & (1u << 10)) != 0) row._current10.Next();
+			if ((m & (1u << 11)) != 0) row._current11.Next();
+			if ((m & (1u << 12)) != 0) row._current12.Next();
+			if ((m & (1u << 13)) != 0) row._current13.Next();
+			if ((m & (1u << 14)) != 0) row._current14.Next();
+			if ((m & (1u << 15)) != 0) row._current15.Next();
             return true;
         }
 

--- a/src/TinyEcs.Bevy/TinyEcs.Bevy.Data.tt
+++ b/src/TinyEcs.Bevy/TinyEcs.Bevy.Data.tt
@@ -36,8 +36,11 @@ namespace TinyEcs.Bevy
         var generics = GenerateSequence(i + 1, ", ", j => $"T{j}");
         var whereGenerics = GenerateSequence(i + 1, " ", j => $"where T{j} : struct");
         var ptrList = GenerateSequence(i + 1, "\n\t\t", j => $"internal DataRow<T{j}> _current{j};");
-        var ptrSetRow = GenerateSequence(i + 1, "\n\t\t\t", j => $"row._current{j} = iterator.GetColumn<T{j}, DataRow<T{j}>>({j});");
-        var ptrAdvanceRow = GenerateSequence(i + 1, "\n\t\t\t", j => $"row._current{j}.Next();");
+        var ptrSetRow = GenerateSequence(i + 1, "\n\t\t\t", j => $"row._current{j} = iterator.GetColumn<T{j}>({j});");
+        var maskBuild = GenerateSequence(i + 1, " |\n\t\t\t\t\t", j => $"(row._current{j}.Value.IsValid() ? (1u << {j}) : 0u)");
+        var ptrAdvanceRow = GenerateSequence(i + 1, "\n\t\t\t\t", j => $"row._current{j}.Next();");
+        var ptrAdvanceRowMasked = GenerateSequence(i + 1, "\n\t\t\t", j => $"if ((m & (1u << {j})) != 0) row._current{j}.Next();");
+        var allPresentMask = ((1L << (i + 1)) - 1).ToString("X") + "u";
         var fieldSign = GenerateSequence(i + 1, ", ", j => $"out Ptr<T{j}> ptr{j}");
         var fieldAssignments = GenerateSequence(i + 1, "\n\t\t\t", j => $"ptr{j} = _current{j}.Value;");
         var queryBuilderCalls = GenerateSequence(i + 1, "\n\t\t\t", j => $"builder.With<T{j}>();");
@@ -47,11 +50,15 @@ namespace TinyEcs.Bevy
     public unsafe ref struct Data<<#= generics #>> : IData<Data<<#= generics #>>>, IQueryComponentAccess
         <#= whereGenerics #>
     {
+        private const uint ALL_PRESENT_MASK = 0x<#= allPresentMask #>;
+
 		private static readonly System.Type[] s_componentTypes = new[] { <#= typeOfs #> };
 		public static System.ReadOnlySpan<System.Type> ReadComponents => s_componentTypes;
         public static System.ReadOnlySpan<System.Type> WriteComponents => s_componentTypes;
 
         internal int _index, _count;
+        internal uint _presentMask;
+        internal bool _anyAbsent;
         internal ReadOnlySpan<EntityView> _entities;
         <#= ptrList #>
 
@@ -64,6 +71,16 @@ namespace TinyEcs.Bevy
         public static void LoadChunk(ref Data<<#= generics #>> row, QueryIterator iterator)
         {
             <#= ptrSetRow #>
+            if (iterator.HasOptional)
+            {
+                row._presentMask =
+                    <#= maskBuild #>;
+                row._anyAbsent = row._presentMask != ALL_PRESENT_MASK;
+            }
+            else
+            {
+                row._anyAbsent = false;
+            }
             row._entities = iterator.Entities();
             row._index = 0;
             row._count = iterator.Count;
@@ -74,7 +91,13 @@ namespace TinyEcs.Bevy
         {
             if (++row._index >= row._count)
                 return false;
-            <#= ptrAdvanceRow #>
+            if (!row._anyAbsent)
+            {
+                <#= ptrAdvanceRow #>
+                return true;
+            }
+            var m = row._presentMask;
+            <#= ptrAdvanceRowMasked #>
             return true;
         }
 

--- a/src/TinyEcs/Archetype.cs
+++ b/src/TinyEcs/Archetype.cs
@@ -4,146 +4,13 @@ using System.Threading;
 namespace TinyEcs;
 
 
-[SkipLocalsInit]
-internal readonly struct Column
-{
-	public readonly Array Data;
-	public readonly uint[] ChangedTicks, AddedTicks;
-
-	internal Column(ref readonly ComponentInfo component, int chunkSize)
-	{
-		Data = Lookup.GetArray(component.ID, chunkSize)!;
-		ChangedTicks = new uint[chunkSize];
-		AddedTicks = new uint[chunkSize];
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void MarkChanged(int index, uint ticks)
-	{
-		ChangedTicks[index] = ticks;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void MarkAdded(int index, uint ticks)
-	{
-		AddedTicks[index] = ticks;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void CopyTo(int srcIdx, ref readonly Column dest, int dstIdx)
-	{
-		Array.Copy(Data, srcIdx, dest.Data, dstIdx, 1);
-		dest.ChangedTicks[dstIdx] = ChangedTicks[srcIdx];
-		dest.AddedTicks[dstIdx] = AddedTicks[srcIdx];
-	}
-}
-
-[SkipLocalsInit]
-internal struct ArchetypeChunk
-{
-	internal readonly Column[]? Columns;
-	internal readonly EntityView[] Entities;
-
-	internal ArchetypeChunk(ReadOnlySpan<ComponentInfo> sign, int chunkSize)
-	{
-		Entities = new EntityView[chunkSize];
-		Columns = new Column[sign.Length];
-		for (var i = 0; i < sign.Length; ++i)
-			Columns[i] = new(in sign[i], chunkSize);
-	}
-
-	public int Count { get; internal set; }
-
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly ref EntityView EntityAt(int row)
-		=> ref Unsafe.Add(ref Entities.AsSpan(0, Count)[0], row & Archetype.CHUNK_THRESHOLD);
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly ref T GetReference<T>(int column) where T : struct
-	{
-		if (column < 0 || column >= Columns!.Length)
-			return ref Unsafe.NullRef<T>();
-
-		var span = new Span<T>(Unsafe.As<T[]>(Columns[column].Data), 0, Count);
-		return ref MemoryMarshal.GetReference(span);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly ref T GetReferenceWithSize<T>(int column, out int sizeInBytes) where T : struct
-	{
-		if (column < 0 || column >= Columns!.Length)
-		{
-			sizeInBytes = 0;
-			return ref Unsafe.NullRef<T>();
-		}
-
-		sizeInBytes = Unsafe.SizeOf<T>();
-
-		var span = new Span<T>(Unsafe.As<T[]>(Columns[column].Data), 0, Count);
-		return ref MemoryMarshal.GetReference(span);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly ref Column GetColumn(int column)
-	{
-		if (column < 0 || column >= Columns!.Length)
-		{
-			return ref Unsafe.NullRef<Column>();
-		}
-
-		return ref Columns[column];
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly ref T GetReferenceAt<T>(int column, int row) where T : struct
-	{
-		ref var reference = ref GetReference<T>(column);
-		if (Unsafe.IsNullRef(ref reference))
-			return ref reference;
-		return ref Unsafe.Add(ref reference, row & Archetype.CHUNK_THRESHOLD);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly Span<T> GetSpan<T>(int column) where T : struct
-	{
-		if (column < 0 || column >= Columns!.Length)
-			return Span<T>.Empty;
-
-		var span = new Span<T>(Unsafe.As<T[]>(Columns[column].Data), 0, Count);
-		return span;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly ReadOnlySpan<EntityView> GetEntities()
-		=> Entities.AsSpan(0, Count);
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void MarkChanged(int column, int row, uint ticks)
-	{
-		Columns![column].MarkChanged(row & Archetype.CHUNK_THRESHOLD, ticks);
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void MarkAdded(int column, int row, uint ticks)
-	{
-		Columns![column].MarkAdded(row & Archetype.CHUNK_THRESHOLD, ticks);
-	}
-}
-
 public sealed class Archetype : IComparable<Archetype>
 {
-	const int ARCHETYPE_INITIAL_CAPACITY = 1;
-
-	internal const int CHUNK_SIZE = 4096;
-	internal const int CHUNK_LOG2 = 12;
-	internal const int CHUNK_THRESHOLD = CHUNK_SIZE - 1;
+	const int INITIAL_CAPACITY = 8;
 
 	private static long _traversalVersion;
 
-
 	private readonly World _world;
-	private ArchetypeChunk[] _chunks;
 	private readonly ComponentComparer _comparer;
 	private readonly FrozenDictionary<EcsID, int> _componentsLookup, _allLookup
 #if USE_PAIR
@@ -152,10 +19,14 @@ public sealed class Archetype : IComparable<Archetype>
 		;
 	internal readonly List<EcsEdge> _add, _remove;
 	private int _count;
+	private int _capacity;
 	private long _lastTraversalVersion;
 	private readonly int[] _fastLookup;
 	private readonly ulong[] _componentBits;
 	private readonly int _bitsetMaxId;
+
+	internal Column[]? _columns;
+	internal EntityView[] _entities;
 
 	internal Archetype(
 		World world,
@@ -171,8 +42,15 @@ public sealed class Archetype : IComparable<Archetype>
 #if USE_PAIR
 		Pairs = All.Where(x => x.ID.IsPair()).ToImmutableArray();
 #endif
-		_chunks = new ArchetypeChunk[ARCHETYPE_INITIAL_CAPACITY];
 
+		_capacity = 0;
+		_entities = Array.Empty<EntityView>();
+		_columns = Components.Length > 0 ? new Column[Components.Length] : null;
+		if (_columns != null)
+		{
+			for (var i = 0; i < Components.Length; ++i)
+				_columns[i] = Lookup.CreateColumn(Components[i].ID, 0);
+		}
 
 		var hash = 0ul;
 		var dict = new Dictionary<EcsID, int>();
@@ -234,28 +112,80 @@ public sealed class Archetype : IComparable<Archetype>
 	public int Count => _count;
 	public readonly ComponentInfo[] All, Components, Tags, Pairs = Array.Empty<ComponentInfo>();
 	public EcsID Id { get; }
-	internal ReadOnlySpan<ArchetypeChunk> Chunks => _chunks.AsSpan(0, (_count + CHUNK_SIZE - 1) >> CHUNK_LOG2);
-	internal int EmptyChunks => _chunks.Length - ((_count + CHUNK_SIZE - 1) >> CHUNK_LOG2);
 
-	private ref ArchetypeChunk GetOrCreateChunk(int index)
+	internal Column[]? Columns => _columns;
+	internal ReadOnlySpan<EntityView> Entities => _entities.AsSpan(0, _count);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal ref EntityView EntityAt(int row) => ref _entities[row];
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public ref T GetReference<T>(int column) where T : struct
 	{
-		index >>= CHUNK_LOG2;
+		if (_columns == null || column < 0 || column >= _columns.Length)
+			return ref Unsafe.NullRef<T>();
 
-		if (index >= _chunks.Length)
-			Array.Resize(ref _chunks, Math.Max(ARCHETYPE_INITIAL_CAPACITY, _chunks.Length * 2));
-
-		ref var chunk = ref _chunks[index];
-		if (chunk.Columns == null)
-		{
-			chunk = new ArchetypeChunk(Components, CHUNK_SIZE);
-		}
-
-		return ref chunk;
+		return ref ((Column<T>)_columns[column]).GetFirstRef();
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	internal ref ArchetypeChunk GetChunk(int index)
-		=> ref _chunks[index >> CHUNK_LOG2];
+	public ref T GetReferenceWithSize<T>(int column, out int sizeInBytes) where T : struct
+	{
+		if (_columns == null || column < 0 || column >= _columns.Length)
+		{
+			sizeInBytes = 0;
+			return ref Unsafe.NullRef<T>();
+		}
+
+		sizeInBytes = Unsafe.SizeOf<T>();
+		return ref ((Column<T>)_columns[column]).GetFirstRef();
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public ref T GetReferenceAt<T>(int column, int row) where T : struct
+	{
+		if (_columns == null || column < 0 || column >= _columns.Length)
+			return ref Unsafe.NullRef<T>();
+
+		return ref ((Column<T>)_columns[column]).GetRef(row);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public Span<T> GetSpan<T>(int column) where T : struct
+	{
+		if (_columns == null || column < 0 || column >= _columns.Length)
+			return Span<T>.Empty;
+
+		return ((Column<T>)_columns[column]).AsSpan(_count);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal Column? GetColumn(int column)
+	{
+		if (_columns == null || column < 0 || column >= _columns.Length)
+			return null;
+		return _columns[column];
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	internal Column<T>? GetColumn<T>(int column) where T : struct
+	{
+		if (_columns == null || column < 0 || column >= _columns.Length)
+			return null;
+		return (Column<T>)_columns[column];
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void MarkChanged(int column, int row, uint ticks)
+	{
+		_columns![column].MarkChanged(row, ticks);
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void MarkAdded(int column, int row, uint ticks)
+	{
+		_columns![column].MarkAdded(row, ticks);
+	}
 
 	internal int GetComponentIndex(EcsID id)
 	{
@@ -304,65 +234,60 @@ public sealed class Archetype : IComparable<Archetype>
 		return size > 0 ? GetComponentIndex(id) : GetAnyIndex(id);
 	}
 
-	internal ref ArchetypeChunk Add(EntityView ent, out int row)
+	private void EnsureCapacity(int needed)
 	{
-		ref var chunk = ref GetOrCreateChunk(_count);
-		chunk.EntityAt(chunk.Count++) = ent;
-		row = _count++;
-		return ref chunk;
+		if (needed <= _capacity)
+			return;
+
+		var newCap = _capacity == 0 ? INITIAL_CAPACITY : _capacity;
+		while (newCap < needed) newCap *= 2;
+
+		Array.Resize(ref _entities, newCap);
+		if (_columns != null)
+		{
+			for (var i = 0; i < _columns.Length; ++i)
+				_columns[i].EnsureCapacity(newCap);
+		}
+
+		_capacity = newCap;
 	}
 
-	internal ref ArchetypeChunk Add(EcsID id, out int newRow)
-		=> ref Add(new(_world, id), out newRow);
+	internal int Add(EntityView ent)
+	{
+		EnsureCapacity(_count + 1);
+		_entities[_count] = ent;
+		return _count++;
+	}
 
-	private EcsID RemoveByRow(ref ArchetypeChunk chunk, int row)
+	internal int Add(EcsID id) => Add(new EntityView(_world, id));
+
+	private EcsID RemoveByRow(int row)
 	{
 		_count -= 1;
 		EcsAssert.Assert(_count >= 0, "Negative count");
 
-		// ref var chunk = ref GetChunk(row);
-		ref var lastChunk = ref GetChunk(_count);
-		var removed = chunk.EntityAt(row).ID;
+		var removed = _entities[row].ID;
 
 		if (row < _count)
 		{
-			EcsAssert.Assert(lastChunk.EntityAt(_count).ID.IsValid(), "Entity is invalid. This should never happen!");
+			EcsAssert.Assert(_entities[_count].ID.IsValid(), "Entity is invalid. This should never happen!");
 
-			chunk.EntityAt(row) = lastChunk.EntityAt(_count);
+			_entities[row] = _entities[_count];
 
-			var srcIdx = _count & CHUNK_THRESHOLD;
-			var dstIdx = row & CHUNK_THRESHOLD;
-			for (var i = 0; i < Components.Length; ++i)
+			if (_columns != null)
 			{
-				lastChunk.Columns![i].CopyTo(srcIdx, in chunk.Columns![i], dstIdx);
+				for (var i = 0; i < _columns.Length; ++i)
+					_columns[i].CopyTo(_count, _columns[i], row);
 			}
 
-			ref var rec = ref _world.GetRecord(chunk.EntityAt(row).ID);
-			rec.Chunk = chunk;
+			ref var rec = ref _world.GetRecord(_entities[row].ID);
 			rec.Row = row;
 		}
-
-		// lastChunk.EntityAt(_count) = EntityView.Invalid;
-		//
-		// for (var i = 0; i < All.Length; ++i)
-		// {
-		// 	if (All[i].Size <= 0)
-		// 		continue;
-		//
-		// 	var lastValidArray = lastChunk.RawComponentData(i);
-		// 	Array.Clear(lastValidArray, _count & CHUNK_THRESHOLD, 1);
-		// }
-
-		lastChunk.Count -= 1;
-		EcsAssert.Assert(lastChunk.Count >= 0, "Negative chunk count");
-
-		TrimChunksIfNeeded();
 
 		return removed;
 	}
 
-	internal EcsID Remove(ref EcsRecord record)
-		=> RemoveByRow(ref record.Chunk, record.Row);
+	internal EcsID Remove(ref EcsRecord record) => RemoveByRow(record.Row);
 
 	internal Archetype InsertVertex(Archetype left, ComponentInfo[] sign, EcsID id)
 	{
@@ -383,9 +308,9 @@ public sealed class Archetype : IComparable<Archetype>
 		return vertex;
 	}
 
-	internal ref ArchetypeChunk MoveEntity(Archetype newArch, ref ArchetypeChunk fromChunk, int oldRow, bool isRemove, out int newRow)
+	internal int MoveEntity(Archetype newArch, int oldRow, bool isRemove)
 	{
-		ref var toChunk = ref newArch.Add(fromChunk.EntityAt(oldRow), out newRow);
+		var newRow = newArch.Add(_entities[oldRow]);
 
 		int i = 0, j = 0;
 		var count = isRemove ? newArch.Components.Length : Components.Length;
@@ -393,8 +318,6 @@ public sealed class Archetype : IComparable<Archetype>
 		ref var x = ref (isRemove ? ref j : ref i);
 		ref var y = ref (!isRemove ? ref j : ref i);
 
-		var srcIdx = oldRow & CHUNK_THRESHOLD;
-		var dstIdx = newRow & CHUNK_THRESHOLD;
 		var items = Components;
 		var newItems = newArch.Components;
 		for (; x < count; ++x, ++y)
@@ -405,12 +328,12 @@ public sealed class Archetype : IComparable<Archetype>
 				++y;
 			}
 
-			fromChunk.Columns![i].CopyTo(srcIdx, in toChunk.Columns![j], dstIdx);
+			_columns![i].CopyTo(oldRow, newArch._columns![j], newRow);
 		}
 
-		_ = RemoveByRow(ref fromChunk, oldRow);
+		_ = RemoveByRow(oldRow);
 
-		return ref toChunk;
+		return newRow;
 	}
 
 	internal void Clear()
@@ -418,16 +341,6 @@ public sealed class Archetype : IComparable<Archetype>
 		_count = 0;
 		_add.Clear();
 		_remove.Clear();
-		TrimChunksIfNeeded();
-	}
-
-	private void TrimChunksIfNeeded()
-	{
-		// Cleanup
-		var empty = EmptyChunks;
-		var half = Math.Max(ARCHETYPE_INITIAL_CAPACITY, _chunks.Length / 2);
-		if (empty > half)
-			Array.Resize(ref _chunks, half);
 	}
 
 	internal void RemoveEmptyArchetypes(ref int removed, Dictionary<EcsID, Archetype> cache)
@@ -542,13 +455,6 @@ public sealed class Archetype : IComparable<Archetype>
 			if (edge.Id == nodeId)
 				return edge.Archetype;
 		}
-
-		// foreach (ref var edge in CollectionsMarshal.AsSpan(onAdd ? root._add : root._remove))
-		// {
-		// 	var found = onAdd ? edge.Archetype.TraverseRight(nodeId) : edge.Archetype.TraverseLeft(nodeId);
-		// 	if (found != null)
-		// 		return found;
-		// }
 
 		return null;
 	}

--- a/src/TinyEcs/Column.cs
+++ b/src/TinyEcs/Column.cs
@@ -1,0 +1,73 @@
+namespace TinyEcs;
+
+internal abstract class Column
+{
+	public uint[] ChangedTicks;
+	public uint[] AddedTicks;
+
+	protected Column(int initialCapacity)
+	{
+		ChangedTicks = initialCapacity > 0 ? new uint[initialCapacity] : Array.Empty<uint>();
+		AddedTicks = initialCapacity > 0 ? new uint[initialCapacity] : Array.Empty<uint>();
+	}
+
+	public abstract int Capacity { get; }
+	public abstract void CopyTo(int srcIdx, Column dst, int dstIdx);
+	public abstract void EnsureCapacity(int capacity);
+	public abstract void SetUntyped(int row, object value);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void MarkChanged(int index, uint ticks) => ChangedTicks[index] = ticks;
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public void MarkAdded(int index, uint ticks) => AddedTicks[index] = ticks;
+
+	protected void GrowTicks(int newCapacity)
+	{
+		Array.Resize(ref ChangedTicks, newCapacity);
+		Array.Resize(ref AddedTicks, newCapacity);
+	}
+}
+
+internal sealed class Column<T> : Column where T : struct
+{
+	internal T[] Data;
+
+	public Column(int initialCapacity) : base(initialCapacity)
+	{
+		Data = initialCapacity > 0 ? new T[initialCapacity] : Array.Empty<T>();
+	}
+
+	public override int Capacity => Data.Length;
+
+	public override void SetUntyped(int row, object value) => Data[row] = (T)value;
+
+	public override void EnsureCapacity(int capacity)
+	{
+		if (Data.Length >= capacity)
+			return;
+
+		var newCap = Data.Length == 0 ? 8 : Data.Length;
+		while (newCap < capacity) newCap *= 2;
+
+		Array.Resize(ref Data, newCap);
+		GrowTicks(newCap);
+	}
+
+	public override void CopyTo(int srcIdx, Column dst, int dstIdx)
+	{
+		var typed = (Column<T>)dst;
+		typed.Data[dstIdx] = Data[srcIdx];
+		typed.ChangedTicks[dstIdx] = ChangedTicks[srcIdx];
+		typed.AddedTicks[dstIdx] = AddedTicks[srcIdx];
+	}
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public ref T GetRef(int index) => ref Data[index];
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public ref T GetFirstRef() => ref MemoryMarshal.GetArrayDataReference(Data);
+
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public Span<T> AsSpan(int count) => Data.AsSpan(0, count);
+}

--- a/src/TinyEcs/Lookup.cs
+++ b/src/TinyEcs/Lookup.cs
@@ -23,6 +23,7 @@ internal static class Lookup
 	private static int _index = 0;
 
 	private static readonly FastIdLookup<Func<int, Array?>> _arrayCreator = new ();
+	private static readonly FastIdLookup<Func<int, Column>> _columnCreator = new ();
 	private static readonly FastIdLookup<ComponentInfo> _components = new ();
 
 	public static ref readonly ComponentInfo GetComponent(EcsID id)
@@ -66,6 +67,39 @@ internal static class Lookup
 		return null;
 	}
 
+	public static Column CreateColumn(EcsID hashcode, int count)
+	{
+		ref var fn = ref _columnCreator.TryGet(hashcode, out var exists);
+		if (exists)
+			return fn(count);
+
+#if USE_PAIR
+		if (hashcode.IsPair())
+		{
+			(var first, var second) = hashcode.Pair();
+
+			fn = ref _columnCreator.TryGet(first, out exists)!;
+			if (exists)
+			{
+				ref var cmp = ref _components.TryGet(first, out exists);
+				if (exists && cmp.Size > 0)
+					return fn(count);
+			}
+
+			fn = ref _columnCreator.TryGet(second, out exists)!;
+			if (exists)
+			{
+				ref var cmp = ref _components.TryGet(second, out exists);
+				if (exists && cmp.Size > 0)
+					return fn(count);
+			}
+		}
+#endif
+
+		EcsAssert.Panic(false, $"component not found with hashcode {hashcode}");
+		return null!;
+	}
+
 
 	[SkipLocalsInit]
     internal static class Component<T> where T : struct
@@ -78,6 +112,7 @@ internal static class Lookup
 		static Component()
 		{
 			_arrayCreator.Add(Value.ID, count => Size > 0 ? new T[count] : Array.Empty<T>());
+			_columnCreator.Add(Value.ID, count => new Column<T>(Size > 0 ? count : 0));
 			_components.Add(Value.ID, Value);
 		}
 

--- a/src/TinyEcs/Ptr.cs
+++ b/src/TinyEcs/Ptr.cs
@@ -38,7 +38,6 @@ public ref struct DataRow<T>
 	where T : struct
 {
 	private Ptr<T> _value;
-	private static readonly nint SizeOf = Unsafe.SizeOf<T>();
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public DataRow(ref T value)
@@ -60,11 +59,7 @@ public ref struct DataRow<T>
 	public Ptr<T> Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _value; }
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public void Next()
-	{
-		// _value.Ref = ref Unsafe.AddByteOffset(ref _value.Ref, SizeOf);
-		_value.Ref = ref Unsafe.Add(ref _value.Ref, 1);
-	}
+	public void Next() => _value.Ref = ref Unsafe.Add(ref _value.Ref, 1);
 }
 
 [SkipLocalsInit]

--- a/src/TinyEcs/Query.cs
+++ b/src/TinyEcs/Query.cs
@@ -92,6 +92,7 @@ public sealed class Query
 	private ulong _lastStructuralVersion;
 	private readonly int[] _indices;
 	private readonly ulong[] _termIdsAccess;
+	private readonly bool _hasOptional;
 
 	internal Query(World world, IQueryTerm[] terms)
 	{
@@ -109,6 +110,8 @@ public sealed class Query
 		{
 			_termIds[i] = _terms[i].Id;
 			_termOps[i] = _terms[i].Op;
+			if (_termOps[i] == TermOp.Optional)
+				_hasOptional = true;
 		}
 
 		var words = world.ComponentBitsetWords;
@@ -160,6 +163,7 @@ public sealed class Query
 	internal ulong[]? WithMask => _withMask;
 	internal ulong[]? WithoutMask => _withoutMask;
 	internal bool FastPath => _fastPath;
+	internal bool HasOptional => _hasOptional;
 
 
 
@@ -215,7 +219,7 @@ public sealed class Query
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private QueryIterator Iter(ReadOnlySpan<Archetype> archetypes, int start, int count)
 	{
-		return new(archetypes, _termIdsAccess, _indices, start, count);
+		return new(archetypes, _termIdsAccess, _indices, start, count, _hasOptional);
 	}
 }
 
@@ -224,27 +228,33 @@ public sealed class Query
 public ref struct QueryIterator
 {
 	private ReadOnlySpan<Archetype>.Enumerator _archetypeIterator;
-	private ReadOnlySpan<ArchetypeChunk>.Enumerator _chunkIterator;
 	private readonly ReadOnlySpan<ulong> _termIds;
 	private readonly Span<int> _indices;
-	private readonly int _start, _startSafe, _count;
+	private readonly int _start, _count;
+	private readonly bool _hasOptional;
 
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	internal QueryIterator(ReadOnlySpan<Archetype> archetypes, ReadOnlySpan<ulong> termIds, Span<int> indices, int start, int count)
+	internal QueryIterator(ReadOnlySpan<Archetype> archetypes, ReadOnlySpan<ulong> termIds, Span<int> indices, int start, int count, bool hasOptional)
 	{
 		_archetypeIterator = archetypes.GetEnumerator();
 		_termIds = termIds;
 		_indices = indices;
 		_start = start;
-		_startSafe = start & Archetype.CHUNK_THRESHOLD;
 		_count = count;
+		_hasOptional = hasOptional;
+	}
+
+	public readonly bool HasOptional
+	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		get => _hasOptional;
 	}
 
 	public readonly int Count
 	{
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		get => _count > 0 ? Math.Min(_count, _chunkIterator.Current.Count) : _chunkIterator.Current.Count;
+		get => _count > 0 ? Math.Min(_count, _archetypeIterator.Current.Count) : _archetypeIterator.Current.Count;
 	}
 
 	public readonly Archetype Archetype => _archetypeIterator.Current;
@@ -256,67 +266,36 @@ public ref struct QueryIterator
 		return _indices.IndexOf(_archetypeIterator.Current.GetComponentIndex<T>());
 	}
 
-#if NET9_0_OR_GREATER
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly TRow GetColumn<T, TRow>(int index)
-		where T : struct
-		where TRow : IDataRow<TRow, T>, allows ref struct
-	{
-		if (index < 0 || index >= _indices.Length)
-			return TRow.CreateAbsent();
-
-		var i = _indices[index];
-		if (i < 0)
-			return TRow.CreateAbsent();
-
-		ref readonly var chunk = ref _chunkIterator.Current;
-		ref var column = ref chunk.GetColumn(i);
-		ref var reference = ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(column.Data));
-
-		return TRow.CreateFrom(ref Unsafe.Add(ref reference, _startSafe));
-	}
-#else
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public readonly DataRow<T> GetColumn<T>(int index) where T : struct
 	{
-		var data = new DataRow<T>();
-
 		if (index < 0 || index >= _indices.Length)
-			return data;
+			return DataRow<T>.CreateAbsent();
 
 		var i = _indices[index];
 		if (i < 0)
-			return data;
+			return DataRow<T>.CreateAbsent();
 
-		ref readonly var chunk = ref _chunkIterator.Current;
-		ref var column = ref chunk.GetColumn(i);
-		ref var reference = ref MemoryMarshal.GetArrayDataReference(Unsafe.As<T[]>(column.Data));
-
-		return new DataRow<T>(ref Unsafe.Add(ref reference, _startSafe));
+		var arch = _archetypeIterator.Current;
+		var column = (Column<T>)arch.Columns![i];
+		return DataRow<T>.CreateFrom(ref Unsafe.Add(ref column.GetFirstRef(), _start));
 	}
-#endif
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public readonly Span<uint> GetChangedTicks(int index)
 	{
 		if (index >= _indices.Length)
-		{
 			return Span<uint>.Empty;
-		}
 
 		var i = _indices[index];
 		if (i < 0)
-		{
 			return Span<uint>.Empty;
-		}
 
-		ref readonly var chunk = ref _chunkIterator.Current;
-		ref var column = ref chunk.GetColumn(i);
-		ref var stateRef = ref MemoryMarshal.GetArrayDataReference(column.ChangedTicks);
-
-		var span = MemoryMarshal.CreateSpan(ref stateRef, column.ChangedTicks.Length);
+		var arch = _archetypeIterator.Current;
+		var column = arch.Columns![i];
+		var span = column.ChangedTicks.AsSpan();
 		if (!span.IsEmpty)
-			span = span.Slice(_startSafe, Count);
+			span = span.Slice(_start, Count);
 		return span;
 	}
 
@@ -324,33 +303,28 @@ public ref struct QueryIterator
 	public readonly Span<uint> GetAddedTicks(int index)
 	{
 		if (index >= _indices.Length)
-		{
 			return Span<uint>.Empty;
-		}
 
 		var i = _indices[index];
 		if (i < 0)
-		{
 			return Span<uint>.Empty;
-		}
 
-		ref readonly var chunk = ref _chunkIterator.Current;
-		ref var column = ref chunk.GetColumn(i);
-		ref var stateRef = ref MemoryMarshal.GetArrayDataReference(column.AddedTicks);
-
-		var span = MemoryMarshal.CreateSpan(ref stateRef, column.AddedTicks.Length);
+		var arch = _archetypeIterator.Current;
+		var column = arch.Columns![i];
+		var span = column.AddedTicks.AsSpan();
 		if (!span.IsEmpty)
-			span = span.Slice(_startSafe, Count);
+			span = span.Slice(_start, Count);
 		return span;
 	}
 
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public readonly Span<T> Data<T>(int index) where T : struct
 	{
-		var span = _chunkIterator.Current.GetSpan<T>(_indices[index]);
+		var arch = _archetypeIterator.Current;
+		var span = arch.GetSpan<T>(_indices[index]);
 
 		if (!span.IsEmpty)
-			span = span.Slice(_startSafe, Count);
+			span = span.Slice(_start, Count);
 
 		return span;
 	}
@@ -358,21 +332,10 @@ public ref struct QueryIterator
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public readonly ReadOnlySpan<EntityView> Entities()
 	{
-		var entities = _chunkIterator.Current.GetEntities();
+		var entities = _archetypeIterator.Current.Entities;
 
 		if (!entities.IsEmpty)
-			entities = entities.Slice(_startSafe, Count);
-
-		return entities;
-	}
-
-	[MethodImpl(MethodImplOptions.AggressiveInlining)]
-	public readonly ReadOnlyMemory<EntityView> EntitiesAsMemory()
-	{
-		var entities = _chunkIterator.Current.Entities.AsMemory(0, _chunkIterator.Current.Count);
-
-		if (!entities.IsEmpty)
-			entities = entities.Slice(_startSafe, Count);
+			entities = entities.Slice(_start, Count);
 
 		return entities;
 	}
@@ -381,24 +344,15 @@ public ref struct QueryIterator
 	public bool Next()
 	{
 	REDO:
-		while (_chunkIterator.MoveNext())
-		{
-			if (_chunkIterator.Current.Count > 0)
-				return true;
-		}
-
-	REDO_1:
 		if (!_archetypeIterator.MoveNext())
 			return false;
 
 		if (_archetypeIterator.Current.Count <= 0)
-			goto REDO_1;
+			goto REDO;
 
 		ref readonly var arch = ref _archetypeIterator.Current;
 		for (var i = 0; i < _indices.Length; ++i)
 			_indices[i] = arch.GetComponentIndex(_termIds[i]);
-		_chunkIterator = arch.Chunks[(_start >> Archetype.CHUNK_LOG2)..].GetEnumerator();
-
-		goto REDO;
+		return true;
 	}
 }

--- a/src/TinyEcs/World.Deferred.cs
+++ b/src/TinyEcs/World.Deferred.cs
@@ -242,10 +242,10 @@ public sealed partial class World
 
 				case DeferredOpTypes.SetComponent:
 					{
-						(var array, var row) = Attach(op.Entity, op.ComponentInfo.ID, op.ComponentInfo.Size);
-						if (array != null && op.Data != null)
+						(var col, var row) = Attach(op.Entity, op.ComponentInfo.ID, op.ComponentInfo.Size);
+						if (col != null && op.Data != null)
 						{
-							array.SetValue(op.Data, row & TinyEcs.Archetype.CHUNK_THRESHOLD);
+							col.SetUntyped(row, op.Data);
 						}
 
 						break;

--- a/src/TinyEcs/World.Public.cs
+++ b/src/TinyEcs/World.Public.cs
@@ -154,7 +154,7 @@ public sealed partial class World
 	{
 		ref var record = ref NewId(out var id);
 		record.Archetype = arch;
-		record.Chunk = arch.Add(id, out record.Row);
+		record.Row = arch.Add(id);
 #if USE_PAIR
 		record.Flags = EntityFlags.None;
 #endif
@@ -185,7 +185,7 @@ public sealed partial class World
 
 				ref var record = ref NewId(out id, id);
 				record.Archetype = _archRoot;
-				record.Chunk = _archRoot.Add(id, out record.Row);
+				record.Row = _archRoot.Add(id);
 #if USE_PAIR
 				record.Flags = EntityFlags.None;
 #endif
@@ -288,18 +288,15 @@ public sealed partial class World
 					using var it = world.GetQueryIterator(terms);
 					while (it.Next(out var arch) && arch != null)
 					{
-						foreach (ref readonly var chunk in arch)
+						foreach (ref readonly var child in arch.Entities)
 						{
-							foreach (ref readonly var child in chunk.Entities.AsSpan(0, chunk.Count))
-							{
-								var action = world.Action(child.ID, entity);
-								if (world.Has<OnDelete, Delete>(action))
-									child.Delete();
-								if (world.Has<OnDelete, Unset>(action))
-									child.Unset(action, entity);
-								if (world.Has<OnDelete, Panic>(action))
-									EcsAssert.Panic(false, "you cant remove this entity because of {OnDelete, Panic} relation");
-							}
+							var action = world.Action(child.ID, entity);
+							if (world.Has<OnDelete, Delete>(action))
+								child.Delete();
+							if (world.Has<OnDelete, Unset>(action))
+								child.Unset(action, entity);
+							if (world.Has<OnDelete, Panic>(action))
+								EcsAssert.Panic(false, "you cant remove this entity because of {OnDelete, Panic} relation");
 						}
 					}
 					world.EndDeferred();
@@ -359,7 +356,7 @@ public sealed partial class World
 		ref var record = ref GetRecord(entity);
 		var index = record.Archetype.GetComponentIndex(component);
 		EcsAssert.Panic(index >= 0, "Component not found in the entity");
-		record.Chunk.MarkChanged(index, record.Row, _ticks);
+		record.Archetype.MarkChanged(index, record.Row, _ticks);
 	}
 
 	/// <inheritdoc cref="SetChanged"/>
@@ -448,11 +445,10 @@ public sealed partial class World
 			return;
 		}
 
-		(var raw, var row) = Attach(entity, cmp.ID, cmp.Size);
+		(var col, var row) = Attach(entity, cmp.ID, cmp.Size);
 		if (cmp.Size <= 0)
 			return;
-		var array = (T[])raw!;
-		array[row & TinyEcs.Archetype.CHUNK_THRESHOLD] = component;
+		((Column<T>)col!).GetRef(row) = component;
 	}
 
 #if USE_PAIR

--- a/src/TinyEcs/World.Relationship.cs
+++ b/src/TinyEcs/World.Relationship.cs
@@ -56,7 +56,7 @@ partial class World
 
         (var raw, var row) = Attach(entity, id, second.Size, second.IsManaged);
         var array = (TTarget[])raw!;
-        array[row & TinyEcs.Archetype.CHUNK_THRESHOLD] = target;
+        array[row] = target;
 	}
 
 	/// <summary>
@@ -108,7 +108,7 @@ partial class World
 
 		(var array, var row) = Attach(entity, pairId, act.Size, act.IsManaged);
 		var cmpArr = Unsafe.As<TAction[]>(array!);
-		cmpArr[row & TinyEcs.Archetype.CHUNK_THRESHOLD] = action;
+		cmpArr[row] = action;
 	}
 
 	/// <summary>

--- a/src/TinyEcs/World.cs
+++ b/src/TinyEcs/World.cs
@@ -137,7 +137,7 @@ public sealed partial class World : IDisposable
 			}
 		}
 
-		record.Chunk = record.Archetype.MoveEntity(foundArch!, ref record.Chunk, record.Row, true, out record.Row);
+		record.Row = record.Archetype.MoveEntity(foundArch!, record.Row, true);
 		record.Archetype = foundArch!;
 		_structuralChangeVersion++;
 		EndDeferred();
@@ -165,7 +165,7 @@ public sealed partial class World : IDisposable
 #endif
 	}
 
-	private (Array?, int) Attach(EcsID entity, EcsID id, int size)
+	private (Column?, int) Attach(EcsID entity, EcsID id, int size)
 	{
 		ref var record = ref GetRecord(entity);
 		var oldArch = record.Archetype;
@@ -178,9 +178,9 @@ public sealed partial class World : IDisposable
 
 			if (size > 0)
 			{
-				record.Chunk.MarkChanged(column, record.Row, _ticks);
+				record.Archetype.MarkChanged(column, record.Row, _ticks);
 			}
-			return (size > 0 ? record.Chunk.Columns![column].Data : null, record.Row);
+			return (size > 0 ? record.Archetype.Columns![column] : null, record.Row);
 		}
 
 		// Component doesn't exist - this is a new addition
@@ -216,7 +216,7 @@ public sealed partial class World : IDisposable
 			}
 		}
 
-		record.Chunk = record.Archetype.MoveEntity(foundArch!, ref record.Chunk, record.Row, false, out record.Row);
+		record.Row = record.Archetype.MoveEntity(foundArch!, record.Row, false);
 		record.Archetype = foundArch!;
 		_structuralChangeVersion++;
 		EndDeferred();
@@ -250,10 +250,10 @@ public sealed partial class World : IDisposable
 		column = size > 0 ? foundArch.GetComponentIndex(id) : foundArch.GetAnyIndex(id);
 		if (size > 0)
 		{
-			record.Chunk.MarkAdded(column, record.Row, _ticks);
-			record.Chunk.MarkChanged(column, record.Row, _ticks);
+			record.Archetype.MarkAdded(column, record.Row, _ticks);
+			record.Archetype.MarkChanged(column, record.Row, _ticks);
 		}
-		return (size > 0 ? record.Chunk.Columns![column].Data : null, record.Row);
+		return (size > 0 ? record.Archetype.Columns![column] : null, record.Row);
 	}
 
 	internal bool IsAttached(ref EcsRecord record, EcsID id)
@@ -360,7 +360,7 @@ public sealed partial class World : IDisposable
 			EcsAssert.Panic(false, $"Component {id} not found on entity {entity}");
 		}
 
-		return ref record.Chunk.GetReferenceAt<T>(column, record.Row);
+		return ref record.Archetype.GetReferenceAt<T>(column, record.Row);
 	}
 }
 
@@ -371,7 +371,6 @@ struct EcsRecord
 #if USE_PAIR
 	public EntityFlags Flags;
 #endif
-	public ArchetypeChunk Chunk;
 }
 
 #if USE_PAIR

--- a/tests/Archetype.cs
+++ b/tests/Archetype.cs
@@ -14,21 +14,9 @@ namespace TinyEcs.Tests
 			var arch = ctx.World.Root;
 
 			for (var i = 0; i < amount; ++i)
-				arch.Add((ulong)(i + 1), out _);
+				arch.Add((ulong)(i + 1));
 
-
-			var total = 0;
-			var chunks = arch.Chunks;
-			for (var i = 0; i < chunks.Length - 1; ++i)
-			{
-				total += chunks[i].Count;
-
-				Assert.Equal(Archetype.CHUNK_SIZE, chunks[i].Count);
-			}
-
-			total += chunks[^1].Count;
-
-			Assert.Equal(arch.Count, total);
+			Assert.Equal(amount, arch.Count);
 		}
 
 		[Theory]
@@ -50,18 +38,7 @@ namespace TinyEcs.Tests
 			entities[entities.Count / 2].Delete();
 
 			var arch = ctx.World.Root;
-			var total = 0;
-			var chunks = arch.Chunks;
-			for (var i = 0; i < chunks.Length - 1; ++i)
-			{
-				total += chunks[i].Count;
-
-				Assert.Equal(Archetype.CHUNK_SIZE, chunks[i].Count);
-			}
-
-			total += chunks[^1].Count;
-
-			Assert.Equal(arch.Count, total);
+			Assert.Equal(amount - 3, arch.Count);
 		}
 	}
 }

--- a/tests/BevyApp.cs
+++ b/tests/BevyApp.cs
@@ -1961,5 +1961,34 @@ namespace TinyEcs.Tests
 			Active
 		}
 
+		[Fact]
+		public void OptionalColumn_DoesNotAdvanceNullRef_AcrossArchetypes()
+		{
+			var app = new App();
+			var w = app.GetWorld();
+
+			// Archetype WITH optional component
+			w.Entity().Set(new Position { X = 1 }).Set(new Velocity { Value = 10 });
+			// Archetype WITHOUT optional component — multiple entities to trigger second-iter NRE
+			w.Entity().Set(new Position { X = 2 });
+			w.Entity().Set(new Position { X = 3 });
+			w.Entity().Set(new Position { X = 4 });
+
+			var seen = new List<(int x, bool hasVel)>();
+			app.AddSystem((Query<Data<Position, Velocity>, Filter<Optional<Velocity>>> q) =>
+			{
+				foreach (var (pos, vel) in q)
+					seen.Add((pos.Ref.X, vel.IsValid()));
+			}).InStage(Stage.Update).Build();
+
+			app.Run();
+
+			Assert.Equal(4, seen.Count);
+			Assert.Contains((1, true), seen);
+			Assert.Contains((2, false), seen);
+			Assert.Contains((3, false), seen);
+			Assert.Contains((4, false), seen);
+		}
+
 	}
 }


### PR DESCRIPTION
Storage rewrite mirroring flecs-dotnet column shape:
- Replace struct Column + ArchetypeChunk with abstract Column class + Column<T> typed concrete. One T[] per component per archetype. No chunked storage. ChangedTicks/AddedTicks scale with archetype size.
- Archetype owns Column[] + EntityView[] directly, grows via doubling Array.Resize. Drop CHUNK_SIZE/LOG2/THRESHOLD.
- EcsRecord drops Chunk field; just Archetype + Row.
- QueryIterator drops chunk iterator; single archetype-level Next loop.
- Attach returns (Column?, int) instead of (Array?, int). Drop RawData. Deferred path uses Column.SetUntyped(row, object) virtual.
- Typed access via Column<T>.GetRef / GetFirstRef / AsSpan; Archetype helpers route through them. AggressiveInlining keeps codegen identical.

Bevy layer:
- Plan C optional handling: QueryIterator.HasOptional gates per-chunk mask build. Fast path (no Optional) pays only one bool branch per row.
- Data<T..N> regen via t4 with mask + _anyAbsent fields.
- DataRow<T> tidy (drop unused SizeOf).

Bench (1M Position/Velocity, 3600 frames, ThreadingMode.Single):
- foreach per-row:  2300 -> ~2280 ms (~tie, compute-bound, throttle-sensitive)
- chunked Span<T>:  2130 -> 1907 ms  (-10%, near DDR4 peak)
- raw query loop:   1967 -> 1905 ms  (-3%)

Memory layout LOH for million-entity archetypes accepted in trade for single-array iteration shape that the JIT can vectorize.

Tests: 153/153 (added Optional NRE regression test).