### PR TITLE
feat(core): per-world component ids

### DIFF
--- a/src/TinyEcs.Bevy/BevyObservers.cs
+++ b/src/TinyEcs.Bevy/BevyObservers.cs
@@ -217,9 +217,6 @@ internal interface IComponentHandler
 /// </summary>
 internal class ComponentHandler<T> : IComponentHandler where T : struct
 {
-	// Store component ID statically to avoid lookups
-	private static ulong? _componentId;
-
 	public void HandleSet(TinyEcs.World world, ulong entityId)
 	{
 		if (!world.Has<T>(entityId))
@@ -246,13 +243,6 @@ internal class ComponentHandler<T> : IComponentHandler where T : struct
 		ref var component = ref world.Get<T>(entityId);
 		world.EmitTriggerInner(new OnRemove<T>(entityId, component));
 	}
-
-	public static void SetComponentId(ulong id)
-	{
-		_componentId = id;
-	}
-
-	public static ulong? GetComponentId() => _componentId;
 }
 
 // ============================================================================
@@ -386,33 +376,18 @@ public static class ObserverExtensions
 	{
 		var state = world.GetObserverState();
 
-		// Check if already registered
-		var existingId = ComponentHandler<T>.GetComponentId();
-		if (existingId.HasValue)
-		{
-			if (!state.ComponentHandlers.ContainsKey(existingId.Value))
-			{
-				state.ComponentHandlers[existingId.Value] = new ComponentHandler<T>();
-			}
-			return;
-		}
-
-		// Temporarily disable hooks to prevent spurious events during registration
+		// Resolve the component id for THIS world. Component ids are per-world,
+		// so the handler must be keyed by the id this world assigned to T.
+		// Temporarily disable hooks to prevent spurious events during registration.
 		var wasEnabled = state.HooksEnabled;
 		state.HooksEnabled = false;
 
-		// Get component entity ID directly - no dummy entity needed!
-		var componentEntity = world.Entity<T>();
-		var componentId = componentEntity.ID;
+		var componentId = world.Entity<T>().ID;
 
-		// Register typed handler first
-		state.ComponentHandlers[componentId] = new ComponentHandler<T>();
-
-		// Store component ID in the handler
-		ComponentHandler<T>.SetComponentId(componentId);
-
-		// Re-enable hooks
 		state.HooksEnabled = wasEnabled;
+
+		if (!state.ComponentHandlers.ContainsKey(componentId))
+			state.ComponentHandlers[componentId] = new ComponentHandler<T>();
 	}
 
 	/// <summary>

--- a/src/TinyEcs/Archetype.cs
+++ b/src/TinyEcs/Archetype.cs
@@ -49,7 +49,7 @@ public sealed class Archetype : IComparable<Archetype>
 		if (_columns != null)
 		{
 			for (var i = 0; i < Components.Length; ++i)
-				_columns[i] = Lookup.CreateColumn(Components[i].ID, 0);
+				_columns[i] = _world.CreateColumn(Components[i].ID, 0);
 		}
 
 		var hash = 0ul;
@@ -229,7 +229,7 @@ public sealed class Archetype : IComparable<Archetype>
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public int GetComponentIndex<T>() where T : struct
 	{
-		var id = Lookup.Component<T>.HashCode;
+		var id = _world.Component<T>().ID;
 		var size = Lookup.Component<T>.Size;
 		return size > 0 ? GetComponentIndex(id) : GetAnyIndex(id);
 	}

--- a/src/TinyEcs/Query.cs
+++ b/src/TinyEcs/Query.cs
@@ -145,7 +145,7 @@ public sealed class Query
 		_withoutMask = fast ? withoutMask : null;
 
 		TermsAccess = terms
-			.Where(s => Lookup.GetComponent(s.Id).Size > 0)
+			.Where(s => World.GetComponentInfo(s.Id).Size > 0)
 			.ToArray();
 
 		_termIdsAccess = new ulong[TermsAccess.Length];

--- a/src/TinyEcs/World.cs
+++ b/src/TinyEcs/World.cs
@@ -14,6 +14,14 @@ public sealed partial class World : IDisposable
 	private readonly int _componentBitsetWords;
 	private readonly FastIdLookup<EcsID> _cachedComponents = new();
 	private readonly object _newEntLock = new();
+
+	// Per-world component registry. Component types share a global dense "slot"
+	// (Lookup.Component<T>.HashCode), but each world assigns its own EcsID to a
+	// type on first use, so component ids are isolated per world.
+	private ComponentInfo[] _slotComponents = new ComponentInfo[64];
+	private bool[] _slotRegistered = new bool[64];
+	private readonly Dictionary<EcsID, int> _idToSlot = new();
+	private ulong _componentCounter;
 	private uint _ticks;
 	private ulong _structuralChangeVersion;
 
@@ -61,36 +69,40 @@ public sealed partial class World : IDisposable
 
 	internal ref readonly ComponentInfo Component<T>() where T : struct
 	{
-		ref readonly var lookup = ref Lookup.Component<T>.Value;
+		// Global dense slot for this component type (stable for the process).
+		var slot = (int)Lookup.Component<T>.HashCode;
+		if (slot >= _slotComponents.Length)
+			GrowSlots(slot);
 
-		EcsAssert.Panic(lookup.ID < _maxCmpId,
-			"Increase the minimum number for components when initializing the world [ex: new World(1024)]");
+		if (!_slotRegistered[slot])
+		{
+			var id = ++_componentCounter;
+			EcsAssert.Panic(id < _maxCmpId,
+				"Increase the minimum number for components when initializing the world [ex: new World(1024)]");
 
-		// 		ref var idx = ref _cachedComponents.GetOrCreate(lookup.ID, out var exists);
-		// 		if (!exists)
-		// 		{
-		// 			idx = Entity(lookup.ID).Set(lookup).ID;
+			_slotComponents[slot] = new ComponentInfo(id, Lookup.Component<T>.Size);
+			_slotRegistered[slot] = true;
+			_idToSlot[id] = slot;
+		}
 
-		// 			NamingEntityMapper.SetName(idx, Lookup.Component<T>.Name);
-
-		// #if USE_PAIR
-		// 			if (!lookup.ID.IsPair())
-		// 			{
-		// 				ref var record = ref GetRecord(lookup.ID);
-
-		// 				if ((record.Flags & EntityFlags.HasName) == 0)
-		// 				{
-		// 					record.Flags |= EntityFlags.HasName;
-		// 					var name = Lookup.Component<T>.Name;
-		// 					_names[name] = lookup.ID;
-		// 					Set<Identifier>(lookup.ID, new (name), Defaults.Name.ID);
-		// 				}
-		// 			}
-		// #endif
-		// 		}
-
-		return ref lookup;
+		return ref _slotComponents[slot];
 	}
+
+	private void GrowSlots(int slot)
+	{
+		var newLen = _slotComponents.Length;
+		while (newLen <= slot) newLen *= 2;
+		Array.Resize(ref _slotComponents, newLen);
+		Array.Resize(ref _slotRegistered, newLen);
+	}
+
+	// Resolve a per-world component id back to its global slot, used to reach the
+	// world-agnostic column/array factories registered in Lookup.
+	internal Column CreateColumn(EcsID id, int count)
+		=> Lookup.CreateColumn((ulong)_idToSlot[id], count);
+
+	internal ref readonly ComponentInfo GetComponentInfo(EcsID id)
+		=> ref _slotComponents[_idToSlot[id]];
 
 
 	internal ref EcsRecord GetRecord(EcsID id)

--- a/tests/ComponentIdIsolation.cs
+++ b/tests/ComponentIdIsolation.cs
@@ -1,0 +1,83 @@
+using TinyEcs.Bevy;
+using Xunit;
+
+namespace TinyEcs.Tests;
+
+public class ComponentIdIsolationTests
+{
+	private struct IsoA { public int Value; }
+	private struct IsoB { public int Value; }
+
+	[Fact]
+	public void ComponentIds_StartFromOne_PerWorld()
+	{
+		var world = new World();
+
+		// First component registered in a fresh world gets id 1; the per-world
+		// counter then advances densely (internal components such as Name may
+		// interleave, so we only assert ordering, not exact later values).
+		var a = world.Entity<IsoA>().ID;
+		var b = world.Entity<IsoB>().ID;
+
+		Assert.Equal(1ul, (ulong)a);
+		Assert.True((ulong)b > (ulong)a);
+	}
+
+	[Fact]
+	public void ComponentIds_AreIndependentPerWorld_OrderDependent()
+	{
+		var worldA = new World();
+		var worldB = new World();
+
+		// Register in opposite order in each world.
+		var aIdInA = worldA.Entity<IsoA>().ID;
+		var bIdInA = worldA.Entity<IsoB>().ID;
+
+		var bIdInB = worldB.Entity<IsoB>().ID;
+		var aIdInB = worldB.Entity<IsoA>().ID;
+
+		// Each world assigns ids by its own registration order, independently.
+		Assert.Equal(aIdInA, bIdInB); // both first-registered in their world
+		Assert.Equal(bIdInA, aIdInB); // both second-registered
+		Assert.NotEqual(aIdInA, aIdInB); // same type, different id across worlds
+	}
+
+	[Fact]
+	public void Storage_IsCorrect_AcrossWorldsWithSameType()
+	{
+		var worldA = new World();
+		var worldB = new World();
+
+		// Skew the id assignment so IsoA has a different id in each world.
+		worldB.Entity<IsoB>(); // bumps worldB's counter first
+
+		var ea = worldA.Entity().Set(new IsoA { Value = 111 });
+		var eb = worldB.Entity().Set(new IsoA { Value = 222 });
+
+		Assert.NotEqual(worldA.Entity<IsoA>().ID, worldB.Entity<IsoA>().ID);
+		Assert.Equal(111, worldA.Get<IsoA>(ea.ID).Value);
+		Assert.Equal(222, worldB.Get<IsoA>(eb.ID).Value);
+	}
+
+	[Fact]
+	public void Query_Works_WithPerWorldIds()
+	{
+		var world = new World();
+
+		world.Entity().Set(new IsoA { Value = 5 }).Set(new IsoB { Value = 7 });
+		world.Entity().Set(new IsoA { Value = 9 });
+
+		var sum = 0;
+		var count = 0;
+		var query = world.Query<Data<IsoA>>();
+		foreach (var row in query)
+		{
+			row.Deconstruct(out var a);
+			sum += a.Ref.Value;
+			count++;
+		}
+
+		Assert.Equal(2, count);
+		Assert.Equal(14, sum);
+	}
+}


### PR DESCRIPTION
Component types previously shared a single process-global id (one static counter in Lookup). Now each World assigns its own EcsID to a type on first use, keyed off the type's global dense slot. Worlds are fully isolated: the same type can hold different ids in different worlds, and ids stay dense per world.

- World keeps a slot->ComponentInfo table + id->slot map + per-world counter; Component<T>() registers lazily on first touch.
- Column/array factories remain static and world-agnostic (keyed by the global slot); Archetype/Query route id-keyed lookups through World.
- Bevy EnableObservers<T> now resolves the component id per world instead of caching it in a static field on ComponentHandler<T> (that cache was correct only while ids were global).

Defaults keep working unchanged (USE_PAIR id wiring untouched).