### PR TITLE
feat(bevy-ui): UiMove + UiScroll pointer picking, App.IsPluginAdded

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -333,6 +333,13 @@ struct PhysicsPlugin : IPlugin
 app.AddPlugin(new PhysicsPlugin { Gravity = 9.81f });
 ```
 
+- Duplicate installs are skipped silently (tracked by type in `_installedPlugins`).
+- **Conditional plugins**: plain `if` + `app.IsPluginAdded<T>()` to gate installs.
+  ```csharp
+  if (!app.IsPluginAdded<PhysicsPlugin>())
+      app.AddPlugin(new PhysicsPlugin());
+  ```
+
 ## Important Implementation Details
 
 ### Ptr<T> and Component Access
@@ -557,6 +564,14 @@ dotnet build samples/TinyEcsGame/TinyEcsGame.csproj   # Sample game
 - `World` is pure ECS storage (entities, components, archetypes, entity-tied observers).
 - Old `world.GetResource<T>()` etc. removed. Use `app.GetResource<T>()` or `Res<T>` system params.
 - Old `<InternalsVisibleTo>` from core to Bevy removed — clean assembly boundary.
+
+### Plugin queries + UI pointer picking (2026-05-29)
+- Added `app.IsPluginAdded<T>()` — public check enabling conditional plugin installs (`BevyApp.cs`).
+- Added `UiMove` and `UiScroll` pointer events to `TinyEcs.Bevy.UI` (`Events.cs`, `InteractionSystem.cs`).
+  - `UiMove` fires on cursor displacement over the hovered entity (carries `Delta`); skips the Over frame and stationary frames.
+  - `UiScroll` dispatches host-fed `UiClayContext.ScrollDelta` to the hovered entity (Bevy Y-up convention).
+  - Both bubble via `propagate: true`. `UiPointer.LastPosition` latches per frame for move delta.
+- See `docs/ui.md` Pointer events table. Tests in `tests/UiBevy.cs`.
 
 ## Migration Notes
 

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -200,6 +200,15 @@ Fired as entity-targeted triggers via `commands.EmitTrigger` during
 | `UiPointerDown`  | Pointer pressed over this entity (press edge).            |
 | `UiPointerUp`    | Pointer released — fires on the **press origin** entity.  |
 | `UiClick`        | Press + release happened on the **same** entity.          |
+| `UiDoubleClick`  | Second `UiClick` on same entity within `DoubleClickWindow`.|
+| `UiMove`         | Pointer moved while over this entity. Carries `Delta`.    |
+| `UiScroll`       | Wheel input dispatched to entity under pointer (`Delta`). |
+
+`UiMove` skips the frame an entity first becomes hovered (that's a `UiOver`)
+and only fires when the cursor actually moved. `UiScroll` reads the host-fed
+`UiClayContext.ScrollDelta` (same input that drives scroll containers) and
+dispatches it to the hovered entity; `Delta` follows Bevy's convention
+(positive Y = scrolled up).
 
 **All UI triggers are emitted with `propagate: true`** — after the hit
 entity's observers run, the trigger bubbles up the parent chain so a

--- a/src/TinyEcs.Bevy.UI/Events.cs
+++ b/src/TinyEcs.Bevy.UI/Events.cs
@@ -12,3 +12,9 @@ public struct UiOver        { }
 public struct UiOut         { }
 public struct UiPointerDown { public Vector2 Position; }
 public struct UiPointerUp   { public Vector2 Position; }
+// Pointer moved while over the target entity. Delta is the cursor displacement
+// since the previous frame (logical pixels).
+public struct UiMove        { public Vector2 Position; public Vector2 Delta; }
+// Scroll wheel input dispatched to the entity under the pointer. Delta follows
+// Bevy's convention: positive Y = scrolled up, positive X = scrolled right.
+public struct UiScroll      { public Vector2 Position; public Vector2 Delta; }

--- a/src/TinyEcs.Bevy.UI/InteractionSystem.cs
+++ b/src/TinyEcs.Bevy.UI/InteractionSystem.cs
@@ -118,6 +118,19 @@ internal static class InteractionSystem
 				(p.Position.X - hoveredBox.X) / MathF.Max(1, hoveredBox.Width),
 				(p.Position.Y - hoveredBox.Y) / MathF.Max(1, hoveredBox.Height));
 			commands.Entity(hovered).Insert(new RelativeCursorPosition { Normalized = rel, InBounds = true });
+
+			// Move: pointer displaced this frame while over the entity. Skip the
+			// first frame an entity becomes hovered (prevHover != hovered) — that's
+			// an Over, not a Move, and LastPosition may be stale.
+			var moveDelta = p.Position - p.LastPosition;
+			if (prevHover == hovered && moveDelta != Vector2.Zero)
+				commands.Entity(hovered).EmitTrigger(new UiMove { Position = p.Position, Delta = moveDelta }, propagate: true);
+
+			// Scroll: wheel input this frame is dispatched to the entity under the
+			// pointer (the layout system separately applies it to scroll containers).
+			var scroll = ctx.Value.ScrollDelta;
+			if (scroll != Vector2.Zero)
+				commands.Entity(hovered).EmitTrigger(new UiScroll { Position = p.Position, Delta = scroll }, propagate: true);
 		}
 
 		if (prevHover != 0 && prevHover != hovered)
@@ -155,5 +168,6 @@ internal static class InteractionSystem
 
 		// Latch pointer edges for next frame
 		p.WasDown = p.Down;
+		p.LastPosition = p.Position;
 	}
 }

--- a/src/TinyEcs.Bevy.UI/Resources.cs
+++ b/src/TinyEcs.Bevy.UI/Resources.cs
@@ -16,6 +16,9 @@ public sealed class UiPointer
 	public Vector2 Position;
 	public bool Down;
 	public bool WasDown;
+	// Previous-frame cursor position, latched by InteractionSystem. Powers UiMove
+	// delta. Not host-fed.
+	public Vector2 LastPosition;
 }
 
 public sealed class UiRenderCommands

--- a/src/TinyEcs.Bevy/BevyApp.cs
+++ b/src/TinyEcs.Bevy/BevyApp.cs
@@ -846,6 +846,14 @@ public class App
 	}
 
 	/// <summary>
+	/// Returns true if a plugin of type <typeparamref name="T"/> has already been installed.
+	/// </summary>
+	public bool IsPluginAdded<T>() where T : IPlugin
+	{
+		return _installedPlugins.Contains(typeof(T));
+	}
+
+	/// <summary>
 	/// Add a system with fluent configuration (must call .InStage() or state transition methods)
 	/// </summary>
 	public ISystemStageSelector AddSystem(ISystem system)

--- a/tests/UiBevy.cs
+++ b/tests/UiBevy.cs
@@ -1401,4 +1401,135 @@ public class UiBevyTests
 			&& c.Rectangle.BackgroundColor.G > 200 && c.Rectangle.BackgroundColor.R < 50);
 		Assert.Equal((short)3, childCmd.ZIndex);
 	}
+
+	private static App MakeInteractiveApp(out System.Func<ulong> spawnedId)
+	{
+		var app = MakeApp();
+		ulong id = 0;
+		app.AddSystem((Commands c) =>
+		{
+			id = c.Spawn()
+				.Insert(new UiNode { Display = Display.Flex, Width = Val.Px(200), Height = Val.Px(100) })
+				.Insert(new BackgroundColor(ClayColor.White))
+				.Insert(new Interaction())
+				.Insert(new FocusPolicy { Block = true })
+				.Id;
+		})
+		.InStage(BevyStage.Startup).SingleThreaded().Build();
+		spawnedId = () => id;
+		return app;
+	}
+
+	[Fact]
+	public void Move_fires_with_delta_when_pointer_moves_over_entity()
+	{
+		var app = MakeInteractiveApp(out _);
+
+		int moveCount = 0;
+		Vector2 lastDelta = default;
+		app.AddObserver<On<UiMove>>(trigger => { moveCount++; lastDelta = trigger.Event.Delta; });
+
+		app.RunStartup();
+		var pointer = app.GetResource<UiPointer>();
+
+		// Frame 1: pointer enters → Over, not Move. Latches LastPosition.
+		pointer.Position = new Vector2(50, 50);
+		app.Update();
+		Assert.Equal(0, moveCount);
+
+		// Frame 2: pointer moved while still over the same entity → Move with delta.
+		pointer.Position = new Vector2(70, 60);
+		app.Update();
+		Assert.Equal(1, moveCount);
+		Assert.Equal(new Vector2(20, 10), lastDelta);
+	}
+
+	[Fact]
+	public void Move_does_not_fire_on_first_hover_frame()
+	{
+		var app = MakeInteractiveApp(out _);
+
+		int moveCount = 0;
+		app.AddObserver<On<UiMove>>(_ => moveCount++);
+
+		app.RunStartup();
+		app.GetResource<UiPointer>().Position = new Vector2(50, 50);
+		app.Update();
+
+		Assert.Equal(0, moveCount);
+	}
+
+	[Fact]
+	public void Move_does_not_fire_when_pointer_stationary()
+	{
+		var app = MakeInteractiveApp(out _);
+
+		int moveCount = 0;
+		app.AddObserver<On<UiMove>>(_ => moveCount++);
+
+		app.RunStartup();
+		var pointer = app.GetResource<UiPointer>();
+		pointer.Position = new Vector2(50, 50);
+		app.Update(); // becomes hovered
+		app.Update(); // same position → no Move
+
+		Assert.Equal(0, moveCount);
+	}
+
+	[Fact]
+	public void Scroll_dispatched_to_hovered_entity()
+	{
+		var app = MakeInteractiveApp(out var idOf);
+
+		int scrollCount = 0;
+		Vector2 lastDelta = default;
+		ulong lastEntity = 0;
+		app.AddObserver<On<UiScroll>>(trigger =>
+		{
+			scrollCount++;
+			lastDelta = trigger.Event.Delta;
+			lastEntity = trigger.EntityId;
+		});
+
+		app.RunStartup();
+		app.GetResource<UiPointer>().Position = new Vector2(50, 50);
+		app.GetResource<UiClayContext>().ScrollDelta = new Vector2(0, 3);
+		app.Update();
+
+		Assert.Equal(1, scrollCount);
+		Assert.Equal(new Vector2(0, 3), lastDelta);
+		Assert.Equal(idOf(), lastEntity);
+	}
+
+	[Fact]
+	public void Scroll_not_fired_when_no_entity_hovered()
+	{
+		var app = MakeInteractiveApp(out _);
+
+		int scrollCount = 0;
+		app.AddObserver<On<UiScroll>>(_ => scrollCount++);
+
+		app.RunStartup();
+		app.GetResource<UiPointer>().Position = new Vector2(500, 500); // off element
+		app.GetResource<UiClayContext>().ScrollDelta = new Vector2(0, 3);
+		app.Update();
+
+		Assert.Equal(0, scrollCount);
+	}
+
+	[Fact]
+	public void Scroll_not_fired_when_delta_zero()
+	{
+		var app = MakeInteractiveApp(out _);
+
+		int scrollCount = 0;
+		app.AddObserver<On<UiScroll>>(_ => scrollCount++);
+
+		app.RunStartup();
+		app.GetResource<UiPointer>().Position = new Vector2(50, 50);
+		// ScrollDelta left at default (zero).
+		app.Update();
+
+		Assert.Equal(0, scrollCount);
+	}
 }


### PR DESCRIPTION
Add UiMove (cursor displacement over hovered entity, carries Delta) and UiScroll (wheel input dispatched to hovered entity) pointer events. Both bubble via propagate:true. UiPointer.LastPosition latches per frame for move delta; UiMove skips the Over frame and stationary frames; UiScroll reads host-fed UiClayContext.ScrollDelta.

Add App.IsPluginAdded<T>() to enable conditional plugin installs.

Docs + CLAUDE.md updated. 6 new tests in tests/UiBevy.cs.